### PR TITLE
Add error visualization geoms and improve density plotting

### DIFF
--- a/ggplot/Kernel/init.m
+++ b/ggplot/Kernel/init.m
@@ -26,6 +26,7 @@ Get["ggplot`geomHistogram`"];
 Get["ggplot`geomErrorBar`"];
 Get["ggplot`geomErrorBoxes`"];
 Get["ggplot`geomErrorBand`"];
+Get["ggplot`geomDensity2DFilled`"];
 
 Get["ggplot`scale`"];
 Get["ggplot`scaleDate`"];

--- a/ggplot/Kernel/init.m
+++ b/ggplot/Kernel/init.m
@@ -25,6 +25,7 @@ Get["ggplot`geomVLine`"];
 Get["ggplot`geomHistogram`"];
 Get["ggplot`geomErrorBar`"];
 Get["ggplot`geomErrorBoxes`"];
+Get["ggplot`geomErrorBand`"];
 
 Get["ggplot`scale`"];
 Get["ggplot`scaleDate`"];

--- a/ggplot/Kernel/init.m
+++ b/ggplot/Kernel/init.m
@@ -23,6 +23,7 @@ Get["ggplot`geomParityLine`"];
 Get["ggplot`geomHLine`"];
 Get["ggplot`geomVLine`"];
 Get["ggplot`geomHistogram`"];
+Get["ggplot`geomErrorBar`"];
 
 Get["ggplot`scale`"];
 Get["ggplot`scaleDate`"];

--- a/ggplot/Kernel/init.m
+++ b/ggplot/Kernel/init.m
@@ -24,6 +24,7 @@ Get["ggplot`geomHLine`"];
 Get["ggplot`geomVLine`"];
 Get["ggplot`geomHistogram`"];
 Get["ggplot`geomErrorBar`"];
+Get["ggplot`geomErrorBoxes`"];
 
 Get["ggplot`scale`"];
 Get["ggplot`scaleDate`"];

--- a/ggplot/geomDensity2DFilled.m
+++ b/ggplot/geomDensity2DFilled.m
@@ -1,0 +1,84 @@
+(* Mathematica Source File *)
+(* Created by Mathematica Plugin for IntelliJ IDEA *)
+(* :Author: andrewyule *)
+(* :Date: 2025-08-02 *)
+
+BeginPackage["ggplot`"];
+
+Begin["`Private`"];
+
+(* geomDensity2DFilled implementation *)
+
+Options[geomDensity2DFilled] = {"data" -> {}, "x" -> Null, "y" -> Null, "color" -> Null, "alpha" -> Null, "levels" -> 10, "bandwidth" -> Automatic, "xScaleFunc" -> Function[Identity[#]], "yScaleFunc" -> Function[Identity[#]]};
+geomDensity2DFilled[opts : OptionsPattern[]] /; Count[Hold[opts], ("data" -> _), {0, Infinity}] > 0 := Module[{newDataset, groupbyKeys, output},
+  (* Ensure X/Y has been given *)
+  If[OptionValue["x"] === Null || OptionValue["y"] === Null, Message[ggplot::xOrYNotGiven]; Throw[Null];];
+
+  newDataset = OptionValue["data"];
+
+  (* Switch dates to absolute times *)
+  newDataset = Replace[newDataset, d_?DateObjectQ :> AbsoluteTime[d], Infinity];
+
+  (* For each key necessary, reconcile the aesthetics and append them to the dataset as a column name i.e. "color_aes" -> somecolor *)
+  newDataset = reconcileAesthetics[newDataset, OptionValue["color"], "color"];
+  newDataset = reconcileAesthetics[newDataset, OptionValue["alpha"], "alpha"];
+
+  (* Group the data based on their aesthetic keys and then apply correct aesthetics while making density primitives *)
+  groupbyKeys = Function[{#["color_aes"], #["alpha_aes"]}];
+  output = newDataset //
+            GroupBy[groupbyKeys] //
+            Values //
+            Map[{
+              #[[1, "color_aes"]],
+              #[[1, "alpha_aes"]],
+              (* Create density contours for the grouped data *)
+              Module[{xVals, yVals, xRange, yRange, kde, contourGraphics, primitives},
+                (* Extract x and y values *)
+                xVals = Map[Function[point,
+                  If[StringQ[OptionValue["x"]], point[OptionValue["x"]], OptionValue["x"][point]]
+                ], #];
+                yVals = Map[Function[point,
+                  If[StringQ[OptionValue["y"]], point[OptionValue["y"]], OptionValue["y"][point]]
+                ], #];
+                
+                (* Apply scaling functions *)
+                xVals = Map[OptionValue["xScaleFunc"], xVals];
+                yVals = Map[OptionValue["yScaleFunc"], yVals];
+                
+                (* Determine data ranges *)
+                xRange = MinMax[xVals];
+                yRange = MinMax[yVals];
+                
+                (* Create kernel density estimation *)
+                kde = SmoothKernelDistribution[Transpose[{xVals, yVals}], 
+                  If[OptionValue["bandwidth"] === Automatic, 
+                    Automatic, 
+                    OptionValue["bandwidth"]]];
+                
+                (* Generate filled contour plot and extract polygons *)
+                contourGraphics = ContourPlot[PDF[kde, {x, y}], 
+                  {x, xRange[[1]], xRange[[2]]}, 
+                  {y, yRange[[1]], yRange[[2]]},
+                  Contours -> OptionValue["levels"],
+                  ContourShading -> True,
+                  ContourLines -> False,
+                  PlotPoints -> 50,
+                  Frame -> False,
+                  Axes -> False
+                ];
+								Print[contourGraphics];
+                
+                (* Extract polygon primitives from the contour plot *)
+                primitives = FullForm[contourGraphics][[1,1]];
+                
+                (* Return the polygons *)
+                Sequence @@ {primitives}
+              ]
+            } &];
+
+  output
+];
+
+End[];
+
+EndPackage[];

--- a/ggplot/geomDensity2DFilled.m
+++ b/ggplot/geomDensity2DFilled.m
@@ -45,9 +45,17 @@ geomDensity2DFilled[opts : OptionsPattern[]] /; Count[Hold[opts], ("data" -> _),
                 xVals = Map[OptionValue["xScaleFunc"], xVals];
                 yVals = Map[OptionValue["yScaleFunc"], yVals];
                 
-                (* Determine data ranges *)
+                (* Determine data ranges and expand them for natural density falloff *)
                 xRange = MinMax[xVals];
                 yRange = MinMax[yVals];
+                
+                (* Expand ranges by 20% on each side for natural density tails *)
+                xSpan = xRange[[2]] - xRange[[1]];
+                ySpan = yRange[[2]] - yRange[[1]];
+                xRangeExpanded = {xRange[[1]] - 0.2*xSpan, xRange[[2]] + 0.2*xSpan};
+                yRangeExpanded = {yRange[[1]] - 0.2*ySpan, yRange[[2]] + 0.2*ySpan};
+
+								Print[xRangeExpanded];
                 
                 (* Create kernel density estimation *)
                 kde = SmoothKernelDistribution[Transpose[{xVals, yVals}], 
@@ -57,8 +65,8 @@ geomDensity2DFilled[opts : OptionsPattern[]] /; Count[Hold[opts], ("data" -> _),
                 
                 (* Generate filled contour plot and extract polygons *)
                 contourGraphics = ContourPlot[PDF[kde, {x, y}], 
-                  {x, xRange[[1]], xRange[[2]]}, 
-                  {y, yRange[[1]], yRange[[2]]},
+                  {x, xRangeExpanded[[1]], xRangeExpanded[[2]]}, 
+                  {y, yRangeExpanded[[1]], yRangeExpanded[[2]]},
                   Contours -> OptionValue["levels"],
                   ContourShading -> True,
                   ContourLines -> False,
@@ -66,10 +74,11 @@ geomDensity2DFilled[opts : OptionsPattern[]] /; Count[Hold[opts], ("data" -> _),
                   Frame -> False,
                   Axes -> False
                 ];
-								Print[contourGraphics];
                 
                 (* Extract polygon primitives from the contour plot *)
                 primitives = FullForm[contourGraphics][[1,1]];
+
+								Print[contourGraphics];
                 
                 (* Return the polygons *)
                 Sequence @@ {primitives}

--- a/ggplot/geomErrorBand.m
+++ b/ggplot/geomErrorBand.m
@@ -1,0 +1,80 @@
+(* Mathematica Source File *)
+(* Created by Mathematica Plugin for IntelliJ IDEA *)
+(* :Author: andrewyule *)
+(* :Date: 2025-08-01 *)
+
+BeginPackage["ggplot`"];
+
+Begin["`Private`"];
+
+(* geomErrorBand implementation *)
+
+Options[geomErrorBand] = {"data" -> {}, "x" -> Null, "ymin" -> Null, "ymax" -> Null, "color" -> Null, "alpha" -> Null, "xScaleFunc" -> Function[Identity[#]], "yScaleFunc" -> Function[Identity[#]]};
+geomErrorBand[opts : OptionsPattern[]] /; Count[Hold[opts], ("data" -> _), {0, Infinity}] > 0 := Module[{newDataset, groupbyKeys, output},
+  (* Ensure all required parameters have been given *)
+  If[OptionValue["x"] === Null || OptionValue["ymin"] === Null || OptionValue["ymax"] === Null, 
+    Message[ggplot::errorBandMissingBounds]; Throw[Null];];
+
+  newDataset = OptionValue["data"];
+
+  (* Switch dates to absolute times *)
+  newDataset = Replace[newDataset, d_?DateObjectQ :> AbsoluteTime[d], Infinity];
+
+  (* For each key necessary, reconcile the aesthetics and append them to the dataset as a column name i.e. "color_aes" -> somecolor *)
+  newDataset = reconcileAesthetics[newDataset, OptionValue["color"], "color"];
+  newDataset = reconcileAesthetics[newDataset, OptionValue["alpha"], "alpha"];
+
+  (* Group the data based on their aesthetic keys and then apply correct aesthetics while making error band primitives *)
+  groupbyKeys = Function[{#["color_aes"], #["alpha_aes"]}];
+  output = newDataset //
+            GroupBy[groupbyKeys] //
+            Values //
+            Map[{
+              #[[1, "color_aes"]],
+              #[[1, "alpha_aes"]],
+              (* Create filled polygon band for the grouped data *)
+              Module[{sortedData, xVals, yminVals, ymaxVals, upperPath, lowerPath, polygonPath},
+                (* Sort data by x values for proper polygon construction *)
+                sortedData = SortBy[#, Function[point,
+                  If[StringQ[OptionValue["x"]], point[OptionValue["x"]], OptionValue["x"][point]]
+                ]];
+                
+                (* Extract and scale the values *)
+                xVals = Map[Function[point,
+                  Module[{xVal},
+                    xVal = If[StringQ[OptionValue["x"]], point[OptionValue["x"]], OptionValue["x"][point]];
+                    OptionValue["xScaleFunc"][xVal]
+                  ]
+                ], sortedData];
+                
+                yminVals = Map[Function[point,
+                  Module[{yminVal},
+                    yminVal = If[StringQ[OptionValue["ymin"]], point[OptionValue["ymin"]], OptionValue["ymin"][point]];
+                    OptionValue["yScaleFunc"][yminVal]
+                  ]
+                ], sortedData];
+                
+                ymaxVals = Map[Function[point,
+                  Module[{ymaxVal},
+                    ymaxVal = If[StringQ[OptionValue["ymax"]], point[OptionValue["ymax"]], OptionValue["ymax"][point]];
+                    OptionValue["yScaleFunc"][ymaxVal]
+                  ]
+                ], sortedData];
+                
+                (* Create paths for upper and lower bounds *)
+                upperPath = Transpose[{xVals, ymaxVals}];
+                lowerPath = Reverse[Transpose[{xVals, yminVals}]];
+                
+                (* Combine into closed polygon *)
+                polygonPath = Join[upperPath, lowerPath];
+                
+                Polygon[polygonPath]
+              ]
+            } &];
+
+  output
+];
+
+End[];
+
+EndPackage[];

--- a/ggplot/geomErrorBar.m
+++ b/ggplot/geomErrorBar.m
@@ -1,0 +1,78 @@
+(* Mathematica Source File *)
+(* Created by Mathematica Plugin for IntelliJ IDEA *)
+(* :Author: andrewyule *)
+(* :Date: 2025-08-01 *)
+
+BeginPackage["ggplot`"];
+
+Begin["`Private`"];
+
+(* geomErrorBar implementation *)
+
+Options[geomErrorBar] = {"data" -> {}, "xmin" -> Null, "xmax" -> Null, "ymin" -> Null, "ymax" -> Null, "color" -> Null, "thickness" -> Null, "alpha" -> Null, "capSize" -> 0.02, "xScaleFunc" -> Function[Identity[#]], "yScaleFunc" -> Function[Identity[#]]};
+geomErrorBar[opts : OptionsPattern[]] /; Count[Hold[opts], ("data" -> _), {0, Infinity}] > 0 := Module[{newDataset, groupbyKeys, output, capSize},
+  (* Ensure all required parameters have been given *)
+  If[OptionValue["xmin"] === Null || OptionValue["xmax"] === Null || OptionValue["ymin"] === Null || OptionValue["ymax"] === Null, 
+    Message[ggplot::errorBarMissingBounds]; Throw[Null];];
+
+  newDataset = OptionValue["data"];
+  capSize = OptionValue["capSize"];
+
+  (* Switch dates to absolute times *)
+  newDataset = Replace[newDataset, d_?DateObjectQ :> AbsoluteTime[d], Infinity];
+
+  (* For each key necessary, reconcile the aesthetics and append them to the dataset as a column name i.e. "color_aes" -> somecolor *)
+  newDataset = reconcileAesthetics[newDataset, OptionValue["color"], "color"];
+  newDataset = reconcileAesthetics[newDataset, OptionValue["alpha"], "alpha"];
+  newDataset = reconcileAesthetics[newDataset, OptionValue["thickness"], "thickness"];
+
+  (* Group the data based on their aesthetic keys and then apply correct aesthetics while making error bar primitives *)
+  groupbyKeys = Function[{#["color_aes"], #["alpha_aes"], #["thickness_aes"]}];
+  output = newDataset //
+            GroupBy[groupbyKeys] //
+            Values //
+            Map[{
+              #[[1, "color_aes"]],
+              #[[1, "alpha_aes"]],
+              #[[1, "thickness_aes"]],
+              (* Create error bar lines for each data point *)
+              Sequence @@ Flatten[Map[Function[point,
+                Module[{xmin, xmax, ymin, ymax, xcenter, ycenter, xminVal, xmaxVal, yminVal, ymaxVal},
+                  (* Calculate bound values - handle both string keys and functions *)
+                  xminVal = If[StringQ[OptionValue["xmin"]], point[OptionValue["xmin"]], OptionValue["xmin"][point]];
+                  xmaxVal = If[StringQ[OptionValue["xmax"]], point[OptionValue["xmax"]], OptionValue["xmax"][point]];
+                  yminVal = If[StringQ[OptionValue["ymin"]], point[OptionValue["ymin"]], OptionValue["ymin"][point]];
+                  ymaxVal = If[StringQ[OptionValue["ymax"]], point[OptionValue["ymax"]], OptionValue["ymax"][point]];
+                  
+                  (* Apply scaling functions *)
+                  xmin = OptionValue["xScaleFunc"][xminVal];
+                  xmax = OptionValue["xScaleFunc"][xmaxVal];
+                  ymin = OptionValue["yScaleFunc"][yminVal];
+                  ymax = OptionValue["yScaleFunc"][ymaxVal];
+                  xcenter = (xmin + xmax)/2;
+                  ycenter = (ymin + ymax)/2;
+                  
+                  {
+                    (* Horizontal error bar *)
+                    Line[{{xmin, ycenter}, {xmax, ycenter}}],
+                    (* Vertical error bar *)
+                    Line[{{xcenter, ymin}, {xcenter, ymax}}],
+                    (* Left cap *)
+                    Line[{{xmin, ycenter - capSize}, {xmin, ycenter + capSize}}],
+                    (* Right cap *)
+                    Line[{{xmax, ycenter - capSize}, {xmax, ycenter + capSize}}],
+                    (* Bottom cap *)
+                    Line[{{xcenter - capSize, ymin}, {xcenter + capSize, ymin}}],
+                    (* Top cap *)
+                    Line[{{xcenter - capSize, ymax}, {xcenter + capSize, ymax}}]
+                  }
+                ]
+              ], #]]
+            } &];
+
+  output
+];
+
+End[];
+
+EndPackage[];

--- a/ggplot/geomErrorBoxes.m
+++ b/ggplot/geomErrorBoxes.m
@@ -1,0 +1,61 @@
+(* Mathematica Source File *)
+(* Created by Mathematica Plugin for IntelliJ IDEA *)
+(* :Author: andrewyule *)
+(* :Date: 2025-08-01 *)
+
+BeginPackage["ggplot`"];
+
+Begin["`Private`"];
+
+(* geomErrorBoxes implementation *)
+
+Options[geomErrorBoxes] = {"data" -> {}, "xmin" -> Null, "xmax" -> Null, "ymin" -> Null, "ymax" -> Null, "color" -> Null, "alpha" -> Null, "xScaleFunc" -> Function[Identity[#]], "yScaleFunc" -> Function[Identity[#]]};
+geomErrorBoxes[opts : OptionsPattern[]] /; Count[Hold[opts], ("data" -> _), {0, Infinity}] > 0 := Module[{newDataset, groupbyKeys, output},
+  (* Ensure all required parameters have been given *)
+  If[OptionValue["xmin"] === Null || OptionValue["xmax"] === Null || OptionValue["ymin"] === Null || OptionValue["ymax"] === Null, 
+    Message[ggplot::errorBarMissingBounds]; Throw[Null];];
+
+  newDataset = OptionValue["data"];
+
+  (* Switch dates to absolute times *)
+  newDataset = Replace[newDataset, d_?DateObjectQ :> AbsoluteTime[d], Infinity];
+
+  (* For each key necessary, reconcile the aesthetics and append them to the dataset as a column name i.e. "color_aes" -> somecolor *)
+  newDataset = reconcileAesthetics[newDataset, OptionValue["color"], "color"];
+  newDataset = reconcileAesthetics[newDataset, OptionValue["alpha"], "alpha"];
+
+  (* Group the data based on their aesthetic keys and then apply correct aesthetics while making error box primitives *)
+  groupbyKeys = Function[{#["color_aes"], #["alpha_aes"]}];
+  output = newDataset //
+            GroupBy[groupbyKeys] //
+            Values //
+            Map[{
+              #[[1, "color_aes"]],
+              #[[1, "alpha_aes"]],
+              (* Create error box rectangles for each data point *)
+              Sequence @@ Map[Function[point,
+                Module[{xmin, xmax, ymin, ymax, xminVal, xmaxVal, yminVal, ymaxVal},
+                  (* Calculate bound values - handle both string keys and functions *)
+                  xminVal = If[StringQ[OptionValue["xmin"]], point[OptionValue["xmin"]], OptionValue["xmin"][point]];
+                  xmaxVal = If[StringQ[OptionValue["xmax"]], point[OptionValue["xmax"]], OptionValue["xmax"][point]];
+                  yminVal = If[StringQ[OptionValue["ymin"]], point[OptionValue["ymin"]], OptionValue["ymin"][point]];
+                  ymaxVal = If[StringQ[OptionValue["ymax"]], point[OptionValue["ymax"]], OptionValue["ymax"][point]];
+                  
+                  (* Apply scaling functions *)
+                  xmin = OptionValue["xScaleFunc"][xminVal];
+                  xmax = OptionValue["xScaleFunc"][xmaxVal];
+                  ymin = OptionValue["yScaleFunc"][yminVal];
+                  ymax = OptionValue["yScaleFunc"][ymaxVal];
+                  
+                  (* Create rectangle from bounds *)
+                  Rectangle[{xmin, ymin}, {xmax, ymax}]
+                ]
+              ], #]
+            } &];
+
+  output
+];
+
+End[];
+
+EndPackage[];

--- a/ggplot/geomPoint.m
+++ b/ggplot/geomPoint.m
@@ -51,6 +51,8 @@ geomPoint[opts : OptionsPattern[]] /; Count[Hold[opts], ("data" -> _), {0, Infin
 
   (* Grouping data but doing a GeometricTransformation on similar Inset values to speed up the plotting once inside Graphics *)
   output = output // GroupBy[Function[{#[[1]], #[[2]], Inset[#[[3, 1]], {0, 0}]}] -> Function[#[[3, 2]]]] // Normal // Map[{#[[1, 1]], #[[1, 2]], GeometricTransformation[#[[1, 3]], List /@ #[[2]]]} &];
+  Print[output];
+
   output
 
 ];

--- a/ggplot/ggplot.m
+++ b/ggplot/ggplot.m
@@ -13,11 +13,12 @@ ggplot::yInterceptNotGiven  = "No yIntercept value was given for geomHLine";
 ggplot::shapeContinuous     = "A continuous variable can not be mapped to a shape";
 ggplot::shapeCount          = "More than 7 discrete shapes are present, aborting... (this should be fixed)";
 ggplot::errorBarMissingBounds = "geomErrorBar requires all four bounds: xmin, xmax, ymin, ymax";
+ggplot::errorBandMissingBounds = "geomErrorBand requires x, ymin, and ymax";
 
 validDatasetQ[dataset_] := MatchQ[dataset, {_?AssociationQ..}];
 
 Attributes[argPatternQ] = {HoldAllComplete};
-argPatternQ[expr___] := MatchQ[Hold[expr], Hold[(_Rule | geomPoint[___] | geomLine[___] | geomPath[___] | geomSmooth[___] | geomVLine[___] | geomHLine[___] | geomParityLine[___] | geomHistogram[___] | geomCol[___] | geomErrorBar[___] | geomErrorBoxes[___] | scaleXDate2[___] | scaleXLinear2[___] | scaleXLog2[___] | scaleYDate2[___] | scaleYLinear2[___] | scaleYLog2[___]) ...]];
+argPatternQ[expr___] := MatchQ[Hold[expr], Hold[(_Rule | geomPoint[___] | geomLine[___] | geomPath[___] | geomSmooth[___] | geomVLine[___] | geomHLine[___] | geomParityLine[___] | geomHistogram[___] | geomCol[___] | geomErrorBar[___] | geomErrorBoxes[___] | geomErrorBand[___] | scaleXDate2[___] | scaleXLinear2[___] | scaleXLog2[___] | scaleYDate2[___] | scaleYLinear2[___] | scaleYLog2[___]) ...]];
 
 (* Main ggplot method and entry point *)
 Options[ggplot] = DeleteDuplicates[Join[{
@@ -80,10 +81,11 @@ ggplot[args___?argPatternQ] /; Count[Hold[args], ("data" -> _), {0, Infinity}] >
   histograms  = Cases[heldArgs, geomHistogram[opts___]  :> geomHistogram[opts,  FilterRules[options, Options[geomHistogram]],  "xScaleFunc" -> xScaleFunc, "yScaleFunc" -> yScaleFunc], {0, Infinity}];
   errorBars   = Cases[heldArgs, geomErrorBar[opts___]   :> geomErrorBar[opts,   FilterRules[options, Options[geomErrorBar]],   "xScaleFunc" -> xScaleFunc, "yScaleFunc" -> yScaleFunc], {0, Infinity}];
   errorBoxes  = Cases[heldArgs, geomErrorBoxes[opts___] :> geomErrorBoxes[opts, FilterRules[options, Options[geomErrorBoxes]], "xScaleFunc" -> xScaleFunc, "yScaleFunc" -> yScaleFunc], {0, Infinity}];
+  errorBands  = Cases[heldArgs, geomErrorBand[opts___]  :> geomErrorBand[opts,  FilterRules[options, Options[geomErrorBand]],  "xScaleFunc" -> xScaleFunc, "yScaleFunc" -> yScaleFunc], {0, Infinity}];
   (* columns need a lot more work to sort through *)
   (*columns     = Cases[{geoms}, geomCol[aesthetics__] :> geomCol[dataset, aesthetics, "xScaleFunc" -> xScaleFunc, "yScaleFunc" -> yScaleFunc], {0, Infinity}];*)
 
-  graphicsPrimitives = {points, lines, paths, smoothLines, abLines, hLines, vLines, histograms, errorBars, errorBoxes} // Flatten;
+  graphicsPrimitives = {points, lines, paths, smoothLines, abLines, hLines, vLines, histograms, errorBars, errorBoxes, errorBands} // Flatten;
 
   (* Tick / GridLine functions passed into ggplot FrameTicks -> _ call *)
   With[{tickAndGridLineOptions = FilterRules[{options}, {Options[ticks2], Options[gridLines2]}]},

--- a/ggplot/ggplot.m
+++ b/ggplot/ggplot.m
@@ -18,7 +18,7 @@ ggplot::errorBandMissingBounds = "geomErrorBand requires x, ymin, and ymax";
 validDatasetQ[dataset_] := MatchQ[dataset, {_?AssociationQ..}];
 
 Attributes[argPatternQ] = {HoldAllComplete};
-argPatternQ[expr___] := MatchQ[Hold[expr], Hold[(_Rule | geomPoint[___] | geomLine[___] | geomPath[___] | geomSmooth[___] | geomVLine[___] | geomHLine[___] | geomParityLine[___] | geomHistogram[___] | geomCol[___] | geomErrorBar[___] | geomErrorBoxes[___] | geomErrorBand[___] | scaleXDate2[___] | scaleXLinear2[___] | scaleXLog2[___] | scaleYDate2[___] | scaleYLinear2[___] | scaleYLog2[___]) ...]];
+argPatternQ[expr___] := MatchQ[Hold[expr], Hold[(_Rule | geomPoint[___] | geomLine[___] | geomPath[___] | geomSmooth[___] | geomVLine[___] | geomHLine[___] | geomParityLine[___] | geomHistogram[___] | geomCol[___] | geomErrorBar[___] | geomErrorBoxes[___] | geomErrorBand[___] | geomDensity2DFilled[___] | scaleXDate2[___] | scaleXLinear2[___] | scaleXLog2[___] | scaleYDate2[___] | scaleYLinear2[___] | scaleYLog2[___]) ...]];
 
 (* Main ggplot method and entry point *)
 Options[ggplot] = DeleteDuplicates[Join[{
@@ -82,10 +82,11 @@ ggplot[args___?argPatternQ] /; Count[Hold[args], ("data" -> _), {0, Infinity}] >
   errorBars   = Cases[heldArgs, geomErrorBar[opts___]   :> geomErrorBar[opts,   FilterRules[options, Options[geomErrorBar]],   "xScaleFunc" -> xScaleFunc, "yScaleFunc" -> yScaleFunc], {0, Infinity}];
   errorBoxes  = Cases[heldArgs, geomErrorBoxes[opts___] :> geomErrorBoxes[opts, FilterRules[options, Options[geomErrorBoxes]], "xScaleFunc" -> xScaleFunc, "yScaleFunc" -> yScaleFunc], {0, Infinity}];
   errorBands  = Cases[heldArgs, geomErrorBand[opts___]  :> geomErrorBand[opts,  FilterRules[options, Options[geomErrorBand]],  "xScaleFunc" -> xScaleFunc, "yScaleFunc" -> yScaleFunc], {0, Infinity}];
+  density2D   = Cases[heldArgs, geomDensity2DFilled[opts___] :> geomDensity2DFilled[opts, FilterRules[options, Options[geomDensity2DFilled]], "xScaleFunc" -> xScaleFunc, "yScaleFunc" -> yScaleFunc], {0, Infinity}];
   (* columns need a lot more work to sort through *)
   (*columns     = Cases[{geoms}, geomCol[aesthetics__] :> geomCol[dataset, aesthetics, "xScaleFunc" -> xScaleFunc, "yScaleFunc" -> yScaleFunc], {0, Infinity}];*)
 
-  graphicsPrimitives = {points, lines, paths, smoothLines, abLines, hLines, vLines, histograms, errorBars, errorBoxes, errorBands} // Flatten;
+  graphicsPrimitives = {points, lines, paths, smoothLines, abLines, hLines, vLines, histograms, errorBars, errorBoxes, errorBands, density2D} // Flatten;
 
   (* Tick / GridLine functions passed into ggplot FrameTicks -> _ call *)
   With[{tickAndGridLineOptions = FilterRules[{options}, {Options[ticks2], Options[gridLines2]}]},

--- a/ggplot/ggplot.m
+++ b/ggplot/ggplot.m
@@ -86,7 +86,7 @@ ggplot[args___?argPatternQ] /; Count[Hold[args], ("data" -> _), {0, Infinity}] >
   (* columns need a lot more work to sort through *)
   (*columns     = Cases[{geoms}, geomCol[aesthetics__] :> geomCol[dataset, aesthetics, "xScaleFunc" -> xScaleFunc, "yScaleFunc" -> yScaleFunc], {0, Infinity}];*)
 
-  graphicsPrimitives = {points, lines, paths, smoothLines, abLines, hLines, vLines, histograms, errorBars, errorBoxes, errorBands, density2D} // Flatten;
+  graphicsPrimitives = {density2D, points, lines, paths, smoothLines, abLines, hLines, vLines, histograms, errorBars, errorBoxes, errorBands} // Flatten;
 
   (* Tick / GridLine functions passed into ggplot FrameTicks -> _ call *)
   With[{tickAndGridLineOptions = FilterRules[{options}, {Options[ticks2], Options[gridLines2]}]},

--- a/ggplot/ggplot.m
+++ b/ggplot/ggplot.m
@@ -17,7 +17,7 @@ ggplot::errorBarMissingBounds = "geomErrorBar requires all four bounds: xmin, xm
 validDatasetQ[dataset_] := MatchQ[dataset, {_?AssociationQ..}];
 
 Attributes[argPatternQ] = {HoldAllComplete};
-argPatternQ[expr___] := MatchQ[Hold[expr], Hold[(_Rule | geomPoint[___] | geomLine[___] | geomPath[___] | geomSmooth[___] | geomVLine[___] | geomHLine[___] | geomParityLine[___] | geomHistogram[___] | geomCol[___] | geomErrorBar[___] | scaleXDate2[___] | scaleXLinear2[___] | scaleXLog2[___] | scaleYDate2[___] | scaleYLinear2[___] | scaleYLog2[___]) ...]];
+argPatternQ[expr___] := MatchQ[Hold[expr], Hold[(_Rule | geomPoint[___] | geomLine[___] | geomPath[___] | geomSmooth[___] | geomVLine[___] | geomHLine[___] | geomParityLine[___] | geomHistogram[___] | geomCol[___] | geomErrorBar[___] | geomErrorBoxes[___] | scaleXDate2[___] | scaleXLinear2[___] | scaleXLog2[___] | scaleYDate2[___] | scaleYLinear2[___] | scaleYLog2[___]) ...]];
 
 (* Main ggplot method and entry point *)
 Options[ggplot] = DeleteDuplicates[Join[{
@@ -79,10 +79,11 @@ ggplot[args___?argPatternQ] /; Count[Hold[args], ("data" -> _), {0, Infinity}] >
   vLines      = Cases[heldArgs, geomVLine[opts___]      :> geomVLine[opts,      FilterRules[options, Options[geomVLine]],      "xScaleFunc" -> xScaleFunc, "yScaleFunc" -> yScaleFunc], {0, Infinity}];
   histograms  = Cases[heldArgs, geomHistogram[opts___]  :> geomHistogram[opts,  FilterRules[options, Options[geomHistogram]],  "xScaleFunc" -> xScaleFunc, "yScaleFunc" -> yScaleFunc], {0, Infinity}];
   errorBars   = Cases[heldArgs, geomErrorBar[opts___]   :> geomErrorBar[opts,   FilterRules[options, Options[geomErrorBar]],   "xScaleFunc" -> xScaleFunc, "yScaleFunc" -> yScaleFunc], {0, Infinity}];
+  errorBoxes  = Cases[heldArgs, geomErrorBoxes[opts___] :> geomErrorBoxes[opts, FilterRules[options, Options[geomErrorBoxes]], "xScaleFunc" -> xScaleFunc, "yScaleFunc" -> yScaleFunc], {0, Infinity}];
   (* columns need a lot more work to sort through *)
   (*columns     = Cases[{geoms}, geomCol[aesthetics__] :> geomCol[dataset, aesthetics, "xScaleFunc" -> xScaleFunc, "yScaleFunc" -> yScaleFunc], {0, Infinity}];*)
 
-  graphicsPrimitives = {points, lines, paths, smoothLines, abLines, hLines, vLines, histograms, errorBars} // Flatten;
+  graphicsPrimitives = {points, lines, paths, smoothLines, abLines, hLines, vLines, histograms, errorBars, errorBoxes} // Flatten;
 
   (* Tick / GridLine functions passed into ggplot FrameTicks -> _ call *)
   With[{tickAndGridLineOptions = FilterRules[{options}, {Options[ticks2], Options[gridLines2]}]},

--- a/ggplot/ggplot.m
+++ b/ggplot/ggplot.m
@@ -12,11 +12,12 @@ ggplot::xInterceptNotGiven  = "No xIntercept value was given for geomHLine";
 ggplot::yInterceptNotGiven  = "No yIntercept value was given for geomHLine";
 ggplot::shapeContinuous     = "A continuous variable can not be mapped to a shape";
 ggplot::shapeCount          = "More than 7 discrete shapes are present, aborting... (this should be fixed)";
+ggplot::errorBarMissingBounds = "geomErrorBar requires all four bounds: xmin, xmax, ymin, ymax";
 
 validDatasetQ[dataset_] := MatchQ[dataset, {_?AssociationQ..}];
 
 Attributes[argPatternQ] = {HoldAllComplete};
-argPatternQ[expr___] := MatchQ[Hold[expr], Hold[(_Rule | geomPoint[___] | geomLine[___] | geomPath[___] | geomSmooth[___] | geomVLine[___] | geomHLine[___] | geomParityLine[___] | geomHistogram[___] | geomCol[___] | scaleXDate2[___] | scaleXLinear2[___] | scaleXLog2[___] | scaleYDate2[___] | scaleYLinear2[___] | scaleYLog2[___]) ...]];
+argPatternQ[expr___] := MatchQ[Hold[expr], Hold[(_Rule | geomPoint[___] | geomLine[___] | geomPath[___] | geomSmooth[___] | geomVLine[___] | geomHLine[___] | geomParityLine[___] | geomHistogram[___] | geomCol[___] | geomErrorBar[___] | scaleXDate2[___] | scaleXLinear2[___] | scaleXLog2[___] | scaleYDate2[___] | scaleYLinear2[___] | scaleYLog2[___]) ...]];
 
 (* Main ggplot method and entry point *)
 Options[ggplot] = DeleteDuplicates[Join[{
@@ -77,10 +78,11 @@ ggplot[args___?argPatternQ] /; Count[Hold[args], ("data" -> _), {0, Infinity}] >
   hLines      = Cases[heldArgs, geomHLine[opts___]      :> geomHLine[opts,      FilterRules[options, Options[geomHLine]],      "xScaleFunc" -> xScaleFunc, "yScaleFunc" -> yScaleFunc], {0, Infinity}];
   vLines      = Cases[heldArgs, geomVLine[opts___]      :> geomVLine[opts,      FilterRules[options, Options[geomVLine]],      "xScaleFunc" -> xScaleFunc, "yScaleFunc" -> yScaleFunc], {0, Infinity}];
   histograms  = Cases[heldArgs, geomHistogram[opts___]  :> geomHistogram[opts,  FilterRules[options, Options[geomHistogram]],  "xScaleFunc" -> xScaleFunc, "yScaleFunc" -> yScaleFunc], {0, Infinity}];
+  errorBars   = Cases[heldArgs, geomErrorBar[opts___]   :> geomErrorBar[opts,   FilterRules[options, Options[geomErrorBar]],   "xScaleFunc" -> xScaleFunc, "yScaleFunc" -> yScaleFunc], {0, Infinity}];
   (* columns need a lot more work to sort through *)
   (*columns     = Cases[{geoms}, geomCol[aesthetics__] :> geomCol[dataset, aesthetics, "xScaleFunc" -> xScaleFunc, "yScaleFunc" -> yScaleFunc], {0, Infinity}];*)
 
-  graphicsPrimitives = {points, lines, paths, smoothLines, abLines, hLines, vLines, histograms} // Flatten;
+  graphicsPrimitives = {points, lines, paths, smoothLines, abLines, hLines, vLines, histograms, errorBars} // Flatten;
 
   (* Tick / GridLine functions passed into ggplot FrameTicks -> _ call *)
   With[{tickAndGridLineOptions = FilterRules[{options}, {Options[ticks2], Options[gridLines2]}]},

--- a/ggplot/ggplotSymbolDeclaration.m
+++ b/ggplot/ggplotSymbolDeclaration.m
@@ -23,6 +23,7 @@ geomHLine::usage        = "TBD";
 geomVLine::usage        = "TBD";
 geomHistogram::usage    = "TBD";
 geomErrorBar::usage    = "TBD";
+geomErrorBoxes::usage    = "TBD";
 
 (* Scales *)
 scaleXLinear2::usage   = "TBD";

--- a/ggplot/ggplotSymbolDeclaration.m
+++ b/ggplot/ggplotSymbolDeclaration.m
@@ -24,6 +24,7 @@ geomVLine::usage        = "TBD";
 geomHistogram::usage    = "TBD";
 geomErrorBar::usage    = "TBD";
 geomErrorBoxes::usage    = "TBD";
+geomErrorBand::usage    = "TBD";
 
 (* Scales *)
 scaleXLinear2::usage   = "TBD";

--- a/ggplot/ggplotSymbolDeclaration.m
+++ b/ggplot/ggplotSymbolDeclaration.m
@@ -25,6 +25,7 @@ geomHistogram::usage    = "TBD";
 geomErrorBar::usage    = "TBD";
 geomErrorBoxes::usage    = "TBD";
 geomErrorBand::usage    = "TBD";
+geomDensity2DFilled::usage    = "TBD";
 
 (* Scales *)
 scaleXLinear2::usage   = "TBD";

--- a/ggplot/ggplotSymbolDeclaration.m
+++ b/ggplot/ggplotSymbolDeclaration.m
@@ -22,6 +22,7 @@ geomParityLine::usage   = "TBD";
 geomHLine::usage        = "TBD";
 geomVLine::usage        = "TBD";
 geomHistogram::usage    = "TBD";
+geomErrorBar::usage    = "TBD";
 
 (* Scales *)
 scaleXLinear2::usage   = "TBD";


### PR DESCRIPTION
Introduce `geomErrorBar`, `geomErrorBoxes`, and `geomErrorBand` for enhanced error visualization. Improve `geomDensity2DFilled` to extend plotting range and ensure proper rendering order for density elements.